### PR TITLE
reducing resulted rows to one on test_positive_values test

### DIFF
--- a/project/dbt_project/macros/test_positive_values.sql
+++ b/project/dbt_project/macros/test_positive_values.sql
@@ -3,5 +3,6 @@
 SELECT *
 FROM {{ model }}
 WHERE {{ column_name }} < 1
+LIMIT 1
 
 {% endtest %}


### PR DESCRIPTION
reducing number of rows that are generated in case of failure of the test_positive_values test macro