### PR TITLE
BUILD/is empty table macro

### DIFF
--- a/project/dbt_project/macros/get_date_range.sql
+++ b/project/dbt_project/macros/get_date_range.sql
@@ -1,24 +1,26 @@
 {% macro get_date_range(target_date='SYSDATE',lookback=7) %}
 
-{%- set date_range_query -%}
+	{%- set date_range_query -%}
 
-	{%- for i in range (0,lookback+1) -%}
+		{%- for i in range (0,lookback+1) -%}
 
-	SELECT {{target_date}}::DATE - {{i}} AS dates
-	{% if not loop.last -%} UNION ALL {%- endif -%}
+		SELECT {{target_date}}::DATE - {{i}} AS dates
+		{% if not loop.last -%} UNION ALL {%- endif -%}
 
-	{%- endfor -%}
+		{%- endfor -%}
 
-{%- endset -%}
+	{%- endset -%}
 
-{%- set date_range_results = run_query(date_range_query) -%}
+	{%- set date_range_results = run_query(date_range_query) -%}
 
-{%- if execute -%}
-	{%- set date_range_results_list = results.columns[0].values() -%}
-{%- else -%}
-	{%- set date_range_results_list = [] -%}
-{%- endif -%}
+	{%- if execute -%}
+		{%- set date_range_results_list = results.columns[0].values() -%}
+	{%- else -%}
+		{%- set date_range_results_list = [] -%}
+	{%- endif -%}
 
-{{return(date_range_results_list)}}
+	
+	{{return(date_range_results_list)}}
+
 
 {% endmacro %}

--- a/project/dbt_project/macros/is_empty.sql
+++ b/project/dbt_project/macros/is_empty.sql
@@ -1,0 +1,21 @@
+{% macro is_empty(schema,model) %}
+
+	{%- set checking_query -%}
+	SELECT COUNT(*) FROM {{schema}}.{{model}} LIMIT 5
+	{%- endset -%}
+
+	{%- set checking_query_result = run_query(checking_query) -%}
+
+	{%- if execute-%}
+		{%-set checking_query_result_list = checking_query_result.columns[0].values() -%}
+	{%- else -%}
+		{%- set checking_query_result_list = [] -%}
+	{%- endif -%}
+
+	{%- if checking_query_result_list[0] == 0 -%}
+		{{return(true)}}
+	{%- else -%}
+		{{return(false)}}
+	{%- endif -%}
+
+{% endmacro %}


### PR DESCRIPTION
This creates a macro that checks if a table is empty, very useful for the first run of incremental models (without needing to change its materialization). It allows you to create a jinja logic to automatically fulfill the historical load of any empty table and to keep the normal incremental logic whenever they already have data.

For instance:

{% if is_empty(schema='schema_1',model='model_1' %}

SELECT * FROM ...
WHERE DATE >= CURRENT_DATE -7

{% else %}

SELECT * FROM ...
WHERE DATE = CURRENT_DATE

{%  endif %}
