### PR TITLE
creating macro get_missing_dates

### DIFF
--- a/project/dbt_project/macros/get_missing_dates.sql
+++ b/project/dbt_project/macros/get_missing_dates.sql
@@ -1,0 +1,22 @@
+{% macro get_missing_dates(schema,model,column,target_date='CURRENT_DATE',lookback=7) %}
+
+	{% set missing_dates_query %}
+	SELECT A.date_actual
+	FROM dev.dim_dates A
+	LEFT JOIN {{schema}}.{{model}} B
+		ON A.date_actual = B.{{column}}
+	WHERE B.{{column}} IS NULL
+		AND A.date_actual BETWEEN {{target_date}}::DATE - {{lookback}} AND {{target_date}}
+	{% endset %}
+
+	{%- set missing_dates_results = run_query(missing_dates_query) -%}
+
+	{%- if execute -%}
+		{%- set missing_dates_list = missing_dates_results.columns[0].values() -%}
+	{%- else -%}
+		{%- set missing_dates_list = [] -%}
+	{%- endif -%}
+
+	{{return(missing_dates_list)}}
+
+{% endmacro %}


### PR DESCRIPTION
This MR creates the **get_missing_dates()** macro, which allows you to get the missing dates in a table using a calendar table as reference. 

There are other parameters such as **target_date**, the final date of the range within we look for the missing dates, and the **lookback**, the number of days that we subtract from the target_date to get the start date of the range